### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/TextToSpeech/CMakeLists.txt
+++ b/TextToSpeech/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(${MODULE_NAME} SHARED
         impl/NetworkStatusObserver.cpp
         impl/SatToken.cpp
         )
+        
 set_target_properties(${MODULE_NAME} PROPERTIES
         CXX_STANDARD 11
         CXX_STANDARD_REQUIRED YES)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated CMake configuration for the TextToSpeech plugin to require C++11 standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->